### PR TITLE
chore: configure dependabot for bun and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+# This project installs with bun, so bun.lock is the real build input.
+#
+# Two Dependabot features are configured separately, and only one of them
+# supports bun today:
+#
+#   Version updates (this file)  : bun IS supported, so the entries below open
+#                                  weekly PRs for outdated dependencies.
+#   Security alerts and security
+#   update PRs                   : bun is NOT supported. GitHub's dependency
+#                                  graph static analysis does not parse
+#                                  bun.lock, so alerts come only from the
+#                                  legacy yarn.lock that is still committed.
+#
+# yarn.lock is stale and is not used to install. It is kept deliberately for
+# now, because deleting it would remove the only source of transitive
+# vulnerability alerts and leave a false clean. Restoring real scanning needs
+# a dependency submission workflow that posts an SBOM built from bun.lock.
+# Delete yarn.lock only after that submission is confirmed populating the
+# dependency graph, so there is never a window with no coverage.
+updates:
+  - package-ecosystem: "bun"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Independent of #22 and #23. Adds the `dependabot.yml` this repository never had.

## What it does

Enables weekly version updates for `bun` and `github-actions`. Both are supported ecosystems, and `bun` is the manager this project actually installs with.

## What it deliberately does not do

It does not delete `yarn.lock`, and that is a reversal of my own earlier recommendation. The reasoning is worth stating, because deleting it looks obviously correct and is not.

All 122 open alerts cite `yarn.lock`. Zero cite `bun.lock`. The repo tracks both, `yarn.lock` last changed 2025-08-04 against `bun.lock` on 2025-12-18, and CI installs with `bun install`. So the alerts are reported against a file that is not a build input, which is why the number is not trustworthy.

But the packages are real. `handlebars`, `axios`, `vite`, `undici`, `tar` and `minimatch` all appear in `bun.lock` too, arriving transitively through semantic-release, vitest and esbuild. So the exposure exists even though the reported versions and scopes come from a stale file.

The trap is what happens on deletion. GitHub's dependency graph static analysis has no `bun` row: the JavaScript entries are npm, pnpm and Yarn. Delete `yarn.lock` and the graph falls back to `package.json` alone, and GitHub's own documentation says indirect dependencies inferred from a manifest rather than a lock file are excluded from vulnerability checks. The 122 alerts would close as fixed and every transitive vulnerability would become invisible.

That is a false clean, and it is strictly worse than inaccurate coverage.

## The actual fix, and the order to do it in

Real scanning for `bun.lock` requires a dependency submission workflow that builds an SBOM and posts it to the Dependency Submission API, which is the documented path for purl-identified ecosystems including bun.

The safe sequence is: land the submission workflow, confirm the graph is populating from `bun.lock`, then delete `yarn.lock`. Doing it in that order means there is never a window with no coverage. I have not built that workflow here, because an SBOM submission that silently fails produces exactly the false clean this PR is avoiding, and I cannot verify it populates the graph until it runs on the default branch.

Also worth knowing for expectations: `bun` supports version updates but **not** security update PRs, so Dependabot will never open an automated fix PR for a bun dependency even once alerts work.

## Scope note

One critical alert is `vitest` and one is `handlebars`, both `scope=development`. This package declares one runtime dependency and ships `files: ["dist"]`, so neither reaches a consumer. This is build-time supply-chain risk for whoever runs the release workflow, not runtime exposure for the backend.
