### PR TITLE
fix: publish the build output, and fail the build instead of exiting 0

### DIFF
--- a/bun.config.ts
+++ b/bun.config.ts
@@ -32,14 +32,17 @@ try {
 		packages: "external",
 	});
 
-	if (ecmascript.success) {
-		console.log("ECMAScript build complete.");
-	}
-
-	if (commonjs.success) {
-		console.log("CommonJS build complete.");
+	for (const [label, result] of [
+		["ECMAScript", ecmascript],
+		["CommonJS", commonjs],
+	] as const) {
+		if (!result.success) {
+			console.error(`${label} build failed:`, result.logs);
+			process.exit(1);
+		}
+		console.log(`${label} build complete.`);
 	}
 } catch (e) {
-	const error = e as AggregateError;
-	console.error("Build Failed:", error);
+	console.error("Build Failed:", e);
+	process.exit(1);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@commitlint/cli": "^19.8.0",
         "@commitlint/config-conventional": "^19.8.0",
         "@commitlint/prompt-cli": "^19.8.0",
+        "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1",
         "@semantic-release/changelog": "^7.0.0",
         "@semantic-release/git": "^11.0.1",
         "@types/bun": "latest",
@@ -123,6 +124,8 @@
     "@connectrpc/connect-node": ["@connectrpc/connect-node@1.4.0", "", { "dependencies": { "undici": "^5.28.3" }, "peerDependencies": { "@bufbuild/protobuf": "^1.4.2", "@connectrpc/connect": "1.4.0" } }, "sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g=="],
 
     "@connectrpc/connect-web": ["@connectrpc/connect-web@1.4.0", "", { "peerDependencies": { "@bufbuild/protobuf": "^1.4.2", "@connectrpc/connect": "1.4.0" } }, "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA=="],
+
+    "@dcspark/cardano-multiplatform-lib-nodejs": ["@dcspark/cardano-multiplatform-lib-nodejs@3.1.2", "", {}, "sha512-bfFI7ljC8El+yj4kG2G7GXcoHHhWJyJKonJ64H3Kcbns4+tHOTy525d1q/u4+hG+G42JPw4Zj5CFIBLv5GLMxg=="],
 
     "@emurgo/cardano-message-signing-nodejs": ["@emurgo/cardano-message-signing-nodejs@1.1.0", "", {}, "sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 	},
 	"scripts": {
 		"build": "bun bun.config.ts",
+		"prepack": "test -f dist/index.cjs && test -f dist/index.mjs && test -f dist/index.d.ts",
 		"test": "vitest --typecheck",
 		"check": "biome check",
 		"lint": "biome lint",
@@ -31,6 +32,7 @@
 		"@commitlint/cli": "^19.8.0",
 		"@commitlint/config-conventional": "^19.8.0",
 		"@commitlint/prompt-cli": "^19.8.0",
+		"@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1",
 		"@semantic-release/changelog": "^7.0.0",
 		"@semantic-release/git": "^11.0.1",
 		"@types/bun": "latest",


### PR DESCRIPTION
2.0.0 is broken on the registry. Its tarball has 3 files and no `dist/`, while `exports` points at `dist/index.cjs`, `dist/index.mjs` and `dist/index.d.ts`. Nobody can import it.

```
$ npm pack @zengate/winter-cardano-mesh@2.0.0 && tar tzf *.tgz
package/LICENSE
package/package.json
package/README.md          <- no dist/
```
1.6.0 shipped 6 files. Packaging inputs (`files`, `.gitignore`, no `.npmignore`) are byte-identical at both tags, so the difference is the run, not the repo.

## Two defects, and the second hid the first

**1. The build breaks on a clean install.** `@dcspark/cardano-multiplatform-lib-nodejs` is an *optional* `peerDependency` of `@cardano-sdk/crypto`, so bun does not install it, yet that package ships a `.d.ts` importing it unconditionally. `dts-bundle-generator` cannot resolve the symbol and throws:

```
error: Cannot find symbol for node "'@dcspark/cardano-multiplatform-lib-nodejs'"
  in "import * as CML from '@dcspark/cardano-multiplatform-lib-nodejs';"
  from node_modules/@cardano-sdk/crypto/dist/esm/strategies/CML.d.ts
```
Reproduced in a clean `--depth 1` clone. It surfaced when the Mesh bump pulled the `@cardano-sdk/crypto` carrying that import. Adding the nodejs flavor as a devDependency, pinned to the `^3.1.1` the peer declares, is also correct for a library built with `target: "node"`.

**2. `bun.config.ts` swallowed it.** The `catch` logged and exited 0, and the success logs sat behind `if (result.success)`, so a failed build printed nothing and still exited 0. **Every `Build Project` step reported success while producing no `dist`, in Release and in CI alike.** The three previous PRs were green on a build that was failing.

## Fixes

- `catch` exits 1; an unsuccessful `Bun.build` prints `result.logs` and exits 1.
- `@dcspark/cardano-multiplatform-lib-nodejs@^3.1.1` as a devDependency.
- `prepack` asserts the three files exist. The build failing the job is the real protection; a broken publish cannot be undone, so the publish path gets its own check.

## Verification

- Clean clone reproduced the failure, then built after the fix.
- `bun run build` on the unfixed tree now exits **1** instead of 0.
- `npm pack --dry-run` with no `dist` exits **1**; with a build it packs **6** files.
- Emitted `index.cjs`, `index.mjs` and `index.d.ts` are **byte-identical** (md5) to a build on a tree where the package was already present, so the published surface is unchanged.
- `bun run check` clean, 25 tests pass, no type errors.

Once this merges, Release cuts **2.0.1** with a real `dist`. 2.0.0 needs deprecating.