### PR TITLE
fix(ci): let the release commit skip the git hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,11 @@ jobs:
       issues: write # to be able to comment on released issues
       pull-requests: write # to be able to comment on released pull requests
       id-token: write # to enable use of OIDC for npm provenance
+    env:
+      # The release commit that @semantic-release/git makes carries the release
+      # notes in its body, and commitlint rejects those long footer lines. The
+      # git hooks exist for a person who commits by hand, not for this job.
+      HUSKY: 0
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
2.0.1 failed to publish. Run [32553133160](https://github.com/zenGate-Global/winter-cardano/actions/runs/32553133160) died in the `prepare` stage:

```
input: chore(release): 2.0.1 [skip ci]

* publish the build output, and fail the build instead of exiting 0 ([#32]...) ([07f0644]...)
[FAIL]   footer's lines must not be longer than 100 characters [footer-max-line-length]
error: "commitlint" exited with code 1
husky - commit-msg script failed (code 1)
  pluginName: '@semantic-release/git'
```

`@semantic-release/git`, which #31 added so `CHANGELOG.md` gets committed back, makes a `chore(release)` commit whose body carries the generated release notes. `prepare: husky` installs the hooks during `bun install`, so `commit-msg` runs commitlint on that bot commit and rejects the long footer lines.

The failure was in `prepare`, which runs before `publish`, so **nothing reached npm**. `latest` is still the broken 2.0.0.

## Fix

`HUSKY: 0` on the release job. That is husky's documented switch. The hooks exist to guard what a person writes by hand; they must not gate a commit the release tool composes. Relaxing `footer-max-line-length` was the alternative and it would weaken the rule for real commits too.

CI is untouched: it runs `bunx commitlint` explicitly on pull request commits, which is the check that should keep its teeth.